### PR TITLE
Fix security vulnerability in System.Text.RegularExpressions

### DIFF
--- a/src/Serilog/NewRelic.Logging.Serilog.Tests/NewRelic.Logging.Serilog.Tests.csproj
+++ b/src/Serilog/NewRelic.Logging.Serilog.Tests/NewRelic.Logging.Serilog.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade System.Text.RegularExpressions to 4.3.1 to fix a regex denial-of-service vulnerability.