### PR TITLE
More build tooling changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,8 +95,24 @@ steps:
     command: 'push'
     packagesToPush: |
       $(Build.ArtifactStagingDirectory)/**/*.nupkg;
-      $(Build.ArtifactStagingDirectory)/**/*.snupkg;
       !$(Build.ArtifactStagingDirectory)/**/*-unreleased*.nupkg;
-      !$(Build.ArtifactStagingDirectory)/**/*-unreleased*.snupkg
     nuGetFeedType: 'external'
     publishFeedCredentials: 'MyGet'
+
+- task: NuGetCommand@2
+  condition: |
+    and (
+      succeeded(),
+      or (
+        eq(variables['Build.SourceBranch'], 'refs/head/master'),
+        startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      )
+    )
+  displayName: 'Push symbols packages to MyGet'
+  inputs:
+    command: 'push'
+    packagesToPush: |
+      $(Build.ArtifactStagingDirectory)/**/*.snupkg;
+      !$(Build.ArtifactStagingDirectory)/**/*-unreleased*.snupkg
+    nuGetFeedType: 'external'
+    publishFeedCredentials: 'MyGetSymbols'

--- a/build/Versioning.targets
+++ b/build/Versioning.targets
@@ -56,9 +56,9 @@
       <Output PropertyName="PreReleaseMoniker" TaskParameter="PreReleaseMoniker" />
     </ParseVersion>
 
-    <!-- If a tag with the correct GitTagPrefix for this product was not found, set the PreReleaseMoniker to 'unreleased'.
+    <!-- If a tag with the correct GitTagPrefix for this product was not found on the commit we're building from, set the PreReleaseMoniker to 'unreleased'.
          This will prevent the resulting NuGet packages from being pushed to MyGet by the Azure build pipeline. -->
-    <PropertyGroup Condition="$(GitExitCode) != 0">
+    <PropertyGroup Condition="$(GitExitCode) != 0 Or $(Revision) > 0">
       <PreReleaseMoniker>unreleased</PreReleaseMoniker>
     </PropertyGroup>
 

--- a/build/Versioning.targets
+++ b/build/Versioning.targets
@@ -36,10 +36,6 @@
     </Exec>
     <Warning Condition="'$(GitExitCode)' > '0'" Text="No tag with prefix '$(GitTagPrefix)' found. Defaulting to version 1.0.0." />
 
-    <PropertyGroup Condition="'$(GitExitCode)' == '0'">
-      <FoundGitTag>true</FoundGitTag>
-    </PropertyGroup>
-
     <Exec Condition="'$(GitExitCode)' == '0'" Command="git rev-list $(LatestTagVersion)..HEAD --count HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
     </Exec>
@@ -60,7 +56,9 @@
       <Output PropertyName="PreReleaseMoniker" TaskParameter="PreReleaseMoniker" />
     </ParseVersion>
 
-    <PropertyGroup Condition="($(PreReleaseMoniker) == '' And $(Revision) > 0) Or ($(FoundGitTag) != 'true')">
+    <!-- If a tag with the correct GitTagPrefix for this product was not found, set the PreReleaseMoniker to 'unreleased'.
+         This will prevent the resulting NuGet packages from being pushed to MyGet by the Azure build pipeline. -->
+    <PropertyGroup Condition="$(GitExitCode) != 0">
       <PreReleaseMoniker>unreleased</PreReleaseMoniker>
     </PropertyGroup>
 

--- a/build/Versioning.targets
+++ b/build/Versioning.targets
@@ -36,6 +36,10 @@
     </Exec>
     <Warning Condition="'$(GitExitCode)' > '0'" Text="No tag with prefix '$(GitTagPrefix)' found. Defaulting to version 1.0.0." />
 
+    <PropertyGroup Condition="'$(GitExitCode)' == '0'">
+      <FoundGitTag>true</FoundGitTag>
+    </PropertyGroup>
+
     <Exec Condition="'$(GitExitCode)' == '0'" Command="git rev-list $(LatestTagVersion)..HEAD --count HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
     </Exec>
@@ -56,7 +60,7 @@
       <Output PropertyName="PreReleaseMoniker" TaskParameter="PreReleaseMoniker" />
     </ParseVersion>
 
-    <PropertyGroup Condition="$(PreReleaseMoniker) == '' And $(Revision) > 0">
+    <PropertyGroup Condition="($(PreReleaseMoniker) == '' And $(Revision) > 0) Or ($(FoundGitTag) != 'true')">
       <PreReleaseMoniker>unreleased</PreReleaseMoniker>
     </PropertyGroup>
 


### PR DESCRIPTION
1. Push symbols packages to a separate MyGet feed; MyGet doesn't support pushing both .nupkg and .snupkg files to the same feed the way that NuGet does.
2. A tweak to `Versioning.targets` to ensure that if a tag is not present for a given product, that product's packages get built with the `unreleased` prerelease moniker, which in turns prevents us from publishing those packages to MyGet.