### PR TITLE
Newrelic log4net appender

### DIFF
--- a/NewRelic.LogEnrichers.sln
+++ b/NewRelic.LogEnrichers.sln
@@ -42,6 +42,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.LogEnrichers.NLog.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.LogEnrichers.NLog.Examples", "examples\NewRelic.LogEnrichers.NLog.Examples\NewRelic.LogEnrichers.NLog.Examples.csproj", "{078EB9EE-92DF-4989-9E6D-679A25C918AF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Log4Net", "Log4Net", "{37DA3549-BF6F-4035-B250-49456744C94B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.LogEnrichers.Log4Net", "src\Log4Net\NewRelic.LogEnrichers.Log4Net\NewRelic.LogEnrichers.Log4Net.csproj", "{F5D96450-8D7C-40BD-87FC-382A1430983F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.LogEnrichers.Log4Net.Tests", "src\Log4Net\NewRelic.LogEnrichers.Log4Net.Tests\NewRelic.LogEnrichers.Log4Net.Tests.csproj", "{08D5269D-E907-4BB9-BE53-17181E3D78F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +78,14 @@ Global
 		{078EB9EE-92DF-4989-9E6D-679A25C918AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{078EB9EE-92DF-4989-9E6D-679A25C918AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{078EB9EE-92DF-4989-9E6D-679A25C918AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5D96450-8D7C-40BD-87FC-382A1430983F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5D96450-8D7C-40BD-87FC-382A1430983F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5D96450-8D7C-40BD-87FC-382A1430983F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5D96450-8D7C-40BD-87FC-382A1430983F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08D5269D-E907-4BB9-BE53-17181E3D78F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08D5269D-E907-4BB9-BE53-17181E3D78F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08D5269D-E907-4BB9-BE53-17181E3D78F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08D5269D-E907-4BB9-BE53-17181E3D78F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +97,8 @@ Global
 		{4AEC595A-A6EB-414C-A0AA-00F66DFB8630} = {76184F97-72D2-46AA-9838-D2DBB7714E19}
 		{1FF12FD5-7282-4CB0-A8D8-D213A05658B1} = {76184F97-72D2-46AA-9838-D2DBB7714E19}
 		{078EB9EE-92DF-4989-9E6D-679A25C918AF} = {76184F97-72D2-46AA-9838-D2DBB7714E19}
+		{F5D96450-8D7C-40BD-87FC-382A1430983F} = {37DA3549-BF6F-4035-B250-49456744C94B}
+		{08D5269D-E907-4BB9-BE53-17181E3D78F4} = {37DA3549-BF6F-4035-B250-49456744C94B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4C9155C8-199D-48A5-BB57-38EB738FA89D}

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
@@ -13,59 +13,76 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
 {
 	public class Log4NetAppenderTests
     {
-        private IAgent _testAgent;
-
         [SetUp]
 		public void Setup()
 		{
-            _testAgent = Mock.Create<IAgent>();
         }
 
         [Test]
 		public void GetLinkingMetadata_CalledOnceForEachEvent()
 		{
             // Arrange
-            const string countLogMessage = "This is a log message";
+            LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
 
-            var testAppender = new NewRelicAppender(() => _testAgent);
-            testAppender.ActivateOptions();
+            var testAgent = Mock.Create<IAgent>();
+            var testAppender = new NewRelicAppender(() => testAgent);
+
+            Mock.Arrange(() => testAgent.GetLinkingMetadata()).Returns(new Dictionary<string, string>() { { "key", "value" } });
 
             //Set the the NewRelicAppender at the root logger
             var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
             BasicConfigurator.Configure(logRepository, testAppender);
 
+            var layout = Mock.Create<log4net.Layout.SimpleLayout>();
+            layout.ActivateOptions();
+
+            var childAppender = new log4net.Appender.ConsoleAppender();
+            childAppender.Layout = layout;
+
+            testAppender.AddAppender(childAppender);
+
+            var testLoggingEvents = new List<LoggingEvent>();
+
+            Mock.Arrange(() => layout.Format(Arg.IsAny<TextWriter>(), Arg.IsAny<LoggingEvent>())).DoInstead((TextWriter textWriter, LoggingEvent loggingEvent) =>
+            {
+                testLoggingEvents.Add(loggingEvent);
+            });
+
             var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
+            //// Act
             var rnd = new Random();
             var countLogAttempts = rnd.Next(2, 25);
 
-            //// Act
             for (var i = 0; i < countLogAttempts; i++)
             {
-                testLogger.Info(countLogMessage);
+                testLogger.Info("This is a log message");
             }
 
             // Assert
-            Mock.Assert(() => _testAgent.GetLinkingMetadata(), Occurs.Exactly(countLogAttempts));
+            Mock.Assert(() => testAgent.GetLinkingMetadata(), Occurs.Exactly(countLogAttempts));
+            Assert.That(testLoggingEvents.Count, Is.EqualTo(countLogAttempts));
+            testLoggingEvents.ForEach(loggingEvent =>
+            {
+                Assert.That(loggingEvent.Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata property found. This test expects newrelic.linkingmetadata property in log event");
+            });
         }
 
         [Test]
         public void GetLinkingMetadata_IsHandled_NullAgent()
         {
             // Arrange
-            var testAppender = new NewRelicAppender(() => _testAgent);
-            testAppender.ActivateOptions();
+            LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
+
+            var testAppender = new NewRelicAppender(() => null);
 
             //Set the the NewRelicAppender at the root logger
             var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
             BasicConfigurator.Configure(logRepository, testAppender);
 
-            var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
             var layout = Mock.Create<log4net.Layout.SimpleLayout>();
             layout.ActivateOptions();
 
-            testAppender.Layout = layout;
             var childAppender = new log4net.Appender.ConsoleAppender();
             childAppender.Layout = layout;
 
@@ -78,6 +95,8 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
                 testLoggingEvents.Add(loggingEvent);
             });
 
+            var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
             // Act
 
             var rnd = new Random();
@@ -89,11 +108,93 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             }
 
             // Assert
+            Assert.That(testLoggingEvents.Count, Is.EqualTo(countLogAttempts));
             testLoggingEvents.ForEach(loggingEvent =>
             {
                 Assert.That(!loggingEvent.Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata property found. This test does not expect newrelic.linkingmetadata property in log event");
             });
         }
 
+        [Test]
+        public void GetLinkingMetadata_IsHandled_Exception()
+        {
+            // Arrange
+            LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
+
+            var testAgent = Mock.Create<IAgent>();
+            var testAppender = new NewRelicAppender(() => testAgent);
+            Mock.Arrange(() => testAgent.GetLinkingMetadata()).DoInstead(() =>
+            {
+                throw new Exception("Exception - GetLinkingMetadata");
+            });
+
+            //Set the the NewRelicAppender at the root logger
+            var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+            BasicConfigurator.Configure(logRepository, testAppender);
+
+            var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+            var layout = Mock.Create<log4net.Layout.SimpleLayout>();
+            var childAppender = new log4net.Appender.ConsoleAppender();
+            childAppender.Layout = layout;
+
+            testAppender.AddAppender(childAppender);
+
+            var testLoggingEvents = new List<LoggingEvent>();
+
+            Mock.Arrange(() => layout.Format(Arg.IsAny<TextWriter>(), Arg.IsAny<LoggingEvent>())).DoInstead((TextWriter textWriter, LoggingEvent loggingEvent) =>
+            {
+                testLoggingEvents.Add(loggingEvent);
+            });
+
+            // Act
+
+            testLogger.Info("This is log message ");
+
+            // Assert
+            Assert.That(testLoggingEvents.Count, Is.EqualTo(1));
+            Assert.That(!testLoggingEvents[0].Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata property found. This test does not expect newrelic.linkingmetadata property in log event");
+        }
+
+        [Test]
+        public void GetLinkingMetadata_IsHandled_NullResult()
+        {
+            // Arrange
+            LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
+
+            var testAgent = Mock.Create<IAgent>();
+            Mock.Arrange(() => testAgent.GetLinkingMetadata()).Returns<Dictionary<string, string>>(null);
+
+            var testAppender = new NewRelicAppender(() => testAgent);
+
+            //Set the the NewRelicAppender at the root logger
+            var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+
+
+            BasicConfigurator.Configure(logRepository, testAppender);
+
+            var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+            var layout = Mock.Create<log4net.Layout.SimpleLayout>();
+            var childAppender = new log4net.Appender.ConsoleAppender();
+            childAppender.Layout = layout;
+
+            testAppender.AddAppender(childAppender);
+
+            var testLoggingEvents = new List<LoggingEvent>();
+
+            Mock.Arrange(() => layout.Format(Arg.IsAny<TextWriter>(), Arg.IsAny<LoggingEvent>())).DoInstead((TextWriter textWriter, LoggingEvent loggingEvent) =>
+            {
+                testLoggingEvents.Add(loggingEvent);
+            });
+
+            // Act
+
+            testLogger.Info("This is log message ");
+
+            // Assert
+            Assert.That(testLoggingEvents.Count, Is.EqualTo(1));
+            Assert.That(!testLoggingEvents[0].Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata property found. This test does not expect newrelic.linkingmetadata property in log event");
+        }
     }
 }

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using log4net;
+using log4net.Config;
+using log4net.Core;
+using NewRelic.Api.Agent;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace NewRelic.LogEnrichers.Log4Net.Tests
+{
+	public class Log4NetAppenderTests
+    {
+        private IAgent _testAgent;
+
+        [SetUp]
+		public void Setup()
+		{
+            _testAgent = Mock.Create<IAgent>();
+        }
+
+        [Test]
+		public void GetLinkingMetadata_CalledOnceForEachEvent()
+		{
+            // Arrange
+            const string countLogMessage = "This is a log message";
+
+            var testAppender = new NewRelicAppender(() => _testAgent);
+            testAppender.ActivateOptions();
+
+            //Set the the NewRelicAppender at the root logger
+            var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+            BasicConfigurator.Configure(logRepository, testAppender);
+
+            var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+            var rnd = new Random();
+            var countLogAttempts = rnd.Next(2, 25);
+
+            //// Act
+            for (var i = 0; i < countLogAttempts; i++)
+            {
+                testLogger.Info(countLogMessage);
+            }
+
+            // Assert
+            Mock.Assert(() => _testAgent.GetLinkingMetadata(), Occurs.Exactly(countLogAttempts));
+        }
+
+        [Test]
+        public void GetLinkingMetadata_IsHandled_NullAgent()
+        {
+            // Arrange
+            var testAppender = new NewRelicAppender(() => _testAgent);
+            testAppender.ActivateOptions();
+
+            //Set the the NewRelicAppender at the root logger
+            var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+            BasicConfigurator.Configure(logRepository, testAppender);
+
+            var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+            var layout = Mock.Create<log4net.Layout.SimpleLayout>();
+            layout.ActivateOptions();
+
+            testAppender.Layout = layout;
+            var childAppender = new log4net.Appender.ConsoleAppender();
+            childAppender.Layout = layout;
+
+            testAppender.AddAppender(childAppender);
+
+            var testLoggingEvents = new List<LoggingEvent>();
+
+            Mock.Arrange(() => layout.Format(Arg.IsAny<TextWriter>(), Arg.IsAny<LoggingEvent>())).DoInstead((TextWriter textWriter, LoggingEvent loggingEvent) => 
+            {
+                testLoggingEvents.Add(loggingEvent);
+            });
+
+            // Act
+
+            var rnd = new Random();
+            var countLogAttempts = rnd.Next(2, 25);
+
+            for (var i = 0; i < countLogAttempts; i++)
+            {
+                testLogger.Info("This is log message " + i);
+            }
+
+            // Assert
+            testLoggingEvents.ForEach(loggingEvent =>
+            {
+                Assert.That(!loggingEvent.Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata property found. This test does not expect newrelic.linkingmetadata property in log event");
+            });
+        }
+
+    }
+}

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
@@ -36,8 +36,10 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             var layout = Mock.Create<log4net.Layout.SimpleLayout>();
             layout.ActivateOptions();
 
-            var childAppender = new log4net.Appender.ConsoleAppender();
-            childAppender.Layout = layout;
+            var childAppender = new log4net.Appender.ConsoleAppender
+            {
+                Layout = layout
+            };
 
             testAppender.AddAppender(childAppender);
 
@@ -83,8 +85,10 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             var layout = Mock.Create<log4net.Layout.SimpleLayout>();
             layout.ActivateOptions();
 
-            var childAppender = new log4net.Appender.ConsoleAppender();
-            childAppender.Layout = layout;
+            var childAppender = new log4net.Appender.ConsoleAppender
+            {
+                Layout = layout
+            };
 
             testAppender.AddAppender(childAppender);
 
@@ -135,8 +139,10 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
             var layout = Mock.Create<log4net.Layout.SimpleLayout>();
-            var childAppender = new log4net.Appender.ConsoleAppender();
-            childAppender.Layout = layout;
+            var childAppender = new log4net.Appender.ConsoleAppender
+            {
+                Layout = layout
+            };
 
             testAppender.AddAppender(childAppender);
 
@@ -176,8 +182,10 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             var testLogger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
             var layout = Mock.Create<log4net.Layout.SimpleLayout>();
-            var childAppender = new log4net.Appender.ConsoleAppender();
-            childAppender.Layout = layout;
+            var childAppender = new log4net.Appender.ConsoleAppender
+            {
+                Layout = layout
+            };
 
             testAppender.AddAppender(childAppender);
 

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
@@ -25,9 +25,9 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
 
             var testAgent = Mock.Create<IAgent>();
-            var testAppender = new NewRelicAppender(() => testAgent);
-
             Mock.Arrange(() => testAgent.GetLinkingMetadata()).Returns(new Dictionary<string, string>() { { "key", "value" } });
+
+            var testAppender = new NewRelicAppender(() => testAgent);
 
             //Set the the NewRelicAppender at the root logger
             var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
@@ -66,7 +66,7 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             Assert.That(testLoggingEvents.Count, Is.EqualTo(countLogAttempts));
             testLoggingEvents.ForEach(loggingEvent =>
             {
-                Assert.That(loggingEvent.Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata property found. This test expects newrelic.linkingmetadata property in log event");
+                Assert.That(loggingEvent.Properties.Contains("newrelic.linkingmetadata"), "newrelic.linkingmetadata not property found. This test expects newrelic.linkingmetadata property in log event");
             });
         }
 
@@ -126,11 +126,13 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
 
             var testAgent = Mock.Create<IAgent>();
-            var testAppender = new NewRelicAppender(() => testAgent);
             Mock.Arrange(() => testAgent.GetLinkingMetadata()).DoInstead(() =>
             {
                 throw new Exception("Exception - GetLinkingMetadata");
             });
+
+            var testAppender = new NewRelicAppender(() => testAgent);
+
 
             //Set the the NewRelicAppender at the root logger
             var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetAppenderTests.cs
@@ -11,16 +11,12 @@ using Telerik.JustMock;
 
 namespace NewRelic.LogEnrichers.Log4Net.Tests
 {
-	public class Log4NetAppenderTests
+    public class Log4NetAppenderTests
     {
-        [SetUp]
-		public void Setup()
-		{
-        }
 
         [Test]
-		public void GetLinkingMetadata_CalledOnceForEachEvent()
-		{
+        public void GetLinkingMetadata_CalledOnceForEachEvent()
+        {
             // Arrange
             LogManager.ShutdownRepository(Assembly.GetEntryAssembly());
 

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>NewRelic.LogEnrichers.Log4Net.Tests</AssemblyName>
+    <RootNamespace>NewRelic.LogEnrichers.Log4Net.Tests</RootNamespace>
+
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\NewRelic.LogEnrichers.StrongNameKey.snk</AssemblyOriginatorKeyFile>
+    <Copyright>Copyright (c) 2008-2020 New Relic, Inc.  All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JustMock" Version="2019.3.910.4" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.20.262" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\TestHelpers.cs" Link="TestHelpers.cs" />
+    <Compile Include="..\..\shared\Asserts.cs" Link="Asserts.cs" />
+    <ProjectReference Include="..\NewRelic.LogEnrichers.Log4Net\NewRelic.LogEnrichers.Log4Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.6" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.20.262" />
   </ItemGroup>
 

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -1,0 +1,59 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <LangVersion>7.1</LangVersion>
+    <RootNamespace>NewRelic.LogEnrichers.Log4Net</RootNamespace>
+    <AssemblyName>NewRelic.LogEnrichers.Log4Net</AssemblyName>
+
+    <Title>New Relic Logging Extension for Log4Net</Title>
+    <Description>.NET library for sending logging context data to New Relic</Description>
+    <Authors>newrelic</Authors>
+
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageIconUrl>https://newrelic.com/images/avatar-newrelic.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/newrelic/newrelic-logenricher-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/newrelic/newrelic-logenricher-dotnet</RepositoryUrl>
+    <PackageReleaseNotes>For detailed information see: https://github.com/newrelic/newrelic-logenricher-dotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <Major>1</Major>
+    <Minor>0</Minor>
+    <Build>0</Build>
+    <Revision>0</Revision>
+    <Version>$(Major).$(Minor).$(Build).$(Revision)</Version>
+    <PackageVersion>$(Major).$(Minor).$(Build)</PackageVersion>
+    <AssemblyVersion>$(Major).0.0.0</AssemblyVersion>
+    <FileVersion>$(Major).$(Minor).$(Build).$(Revision)</FileVersion>
+
+    <GitTagPrefix>Log4Net_v</GitTagPrefix>
+
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\NewRelic.LogEnrichers.StrongNameKey.snk</AssemblyOriginatorKeyFile>
+    <Copyright>Copyright (c) 2008-2020 New Relic, Inc.  All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.6" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.20.262" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>NewRelic.LogEnrichers.Log4Net.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010009b42ffa7e9f9f92ef6313376ea85513f88ac004413378fd3c3eb414f897da70d3d36d54598f14fa6fe21aef9d0cd30747408c927627dd125cf17d29a6b7f8574a552c295d9d605266d8830630dbc09b6a7569e1f4664f51833d8a9d0f2745ff1351dd5ba7762a94812ba13667f6d51943671a47e5378e8b62368c87b39a57a3</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\shared\DateTimeExtensions.cs" Link="DateTimeExtensions.cs" />
+    <Compile Include="..\..\shared\LoggingExtensions.cs" Link="LoggingExtensions.cs" />
+    <None Include="..\..\..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\..\..\NewRelic.LogEnrichers.StrongNameKey.snk" Link="NewRelic.LogEnrichers.StrongNameKey.snk" />
+  </ItemGroup>
+
+</Project>

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using log4net.Appender;
+using log4net.Core;
+using NewRelic.Api.Agent;
+
+namespace NewRelic.LogEnrichers.Log4Net
+{
+	public class NewRelicAppender : ForwardingAppender
+	{
+        private const string LinkingMetadataKey = "newrelic.linkingmetadata";
+        private readonly Lazy<IAgent> _nrAgent;
+
+        internal NewRelicAppender(Func<IAgent> agentFactory)
+        {
+            _nrAgent = new Lazy<IAgent>(agentFactory);
+        }
+
+        public NewRelicAppender() : this(NewRelic.Api.Agent.NewRelic.GetAgent)
+        {
+        }
+
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            var linkingMetadata = _nrAgent.Value?.GetLinkingMetadata();
+
+            if (linkingMetadata != null && linkingMetadata.Keys.Count != 0)
+            {
+                loggingEvent.Properties[LinkingMetadataKey] = linkingMetadata;
+            }
+
+            base.Append(loggingEvent);
+        }
+
+        protected override void Append(LoggingEvent[] loggingEvents)
+        {
+            var linkingMetadata = _nrAgent.Value?.GetLinkingMetadata();
+
+            if (linkingMetadata != null && linkingMetadata.Keys.Count != 0)
+            {
+                foreach (var loggingEvent in loggingEvents)
+                {
+                    loggingEvent.Properties[LinkingMetadataKey] = linkingMetadata;
+                }
+            }
+
+            base.Append(loggingEvents);
+        }
+    }
+}

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using log4net.Appender;
 using log4net.Core;
+using log4net.Util;
 using NewRelic.Api.Agent;
 
 namespace NewRelic.LogEnrichers.Log4Net
@@ -22,29 +23,21 @@ namespace NewRelic.LogEnrichers.Log4Net
 
         protected override void Append(LoggingEvent loggingEvent)
         {
-            var linkingMetadata = _nrAgent.Value?.GetLinkingMetadata();
-
-            if (linkingMetadata != null && linkingMetadata.Keys.Count != 0)
+            try
             {
-                loggingEvent.Properties[LinkingMetadataKey] = linkingMetadata;
-            }
+                var linkingMetadata = _nrAgent.Value?.GetLinkingMetadata();
 
-            base.Append(loggingEvent);
-        }
-
-        protected override void Append(LoggingEvent[] loggingEvents)
-        {
-            var linkingMetadata = _nrAgent.Value?.GetLinkingMetadata();
-
-            if (linkingMetadata != null && linkingMetadata.Keys.Count != 0)
-            {
-                foreach (var loggingEvent in loggingEvents)
+                if (linkingMetadata != null && linkingMetadata.Keys.Count != 0)
                 {
                     loggingEvent.Properties[LinkingMetadataKey] = linkingMetadata;
                 }
+            } 
+            catch(Exception ex) 
+            {
+                LogLog.Error(GetType(), "Exception caught in NewRelicAppender.Append", ex);
             }
 
-            base.Append(loggingEvents);
+            base.Append(loggingEvent);
         }
     }
 }

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
@@ -33,7 +33,7 @@ namespace NewRelic.LogEnrichers.Log4Net
             } 
             catch(Exception ex) 
             {
-                LogLog.Error(GetType(), "Exception caught in NewRelicAppender.Append", ex);
+                LogLog.Error(GetType(), "Exception caught in NewRelic.LogEnrichers.Log4Net.NewRelicAppender.Append", ex);
             }
 
             base.Append(loggingEvent);

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicAppender.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using log4net.Appender;
 using log4net.Core;
 using log4net.Util;

--- a/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -25,7 +25,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
         private const string LogMessage = "This is a log message";
         private const string UserPropertiesKey = "Message Properties";
 
-        private static Dictionary<string,string> linkingMetadataDict = new Dictionary<string, string>
+        private static readonly Dictionary<string,string> linkingMetadataDict = new Dictionary<string, string>
             {
                 { "trace.id", "trace-id" },
                 { "span.id", "span-id" },
@@ -40,8 +40,10 @@ namespace NewRelic.LogEnrichers.NLog.Tests
         public void Setup()
         {
             _testAgent = Mock.Create<IAgent>();
-            _target = new DebugTarget("testTarget");
-            _target.Layout = new NewRelicJsonLayout(() => _testAgent);
+            _target = new DebugTarget("testTarget")
+            {
+                Layout = new NewRelicJsonLayout(() => _testAgent)
+            };
 
             var config = new LoggingConfiguration();
             config.AddTarget(_target);

--- a/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
+++ b/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
@@ -26,7 +26,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
         private const string StringTestValue = "test-string";
         private const string TestErrMsg = "This is a test exception";
         private const string LogMessage = "This is a log message";
-        private const int countIntrinsicProperties = 4;
+        private const int CountIntrinsicProperties = 4;
 
         private readonly NewRelicLoggingProperty[] _newRelicPropertiesNotReserved;
         private readonly NewRelicLoggingProperty[] _newRelicPropertiesReserved = new[]
@@ -85,7 +85,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + IntegerTestKey, IntegerTestValue);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + NullTestKey, JsonValueKind.Null);
             Assert.That(resultDic, Does.Not.ContainKey(UserPropertyKeyPrefix + LinkingMetadataKey));
@@ -118,7 +118,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + IntegerTestKey, IntegerTestValue);
             Assert.That(resultDic, Does.Not.ContainKey(UserPropertyKeyPrefix + LinkingMetadataKey));
             Asserts.KeyAndValueMatch(resultDic, StringATestKey, StringTestValue);
@@ -173,7 +173,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + IntegerTestKey, IntegerTestValue);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + "@" + SingleAtSignTestKey, BooleanTestValue);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + DoubleAtSignTestKey, JsonValueKind.Null);
@@ -202,7 +202,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + IntegerTestKey, IntegerTestValue);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + BooleanTestKey, BooleanTestValue);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + NullTestKey, JsonValueKind.Null);
@@ -234,7 +234,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties + 3, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties + 3, resultDic);
             Asserts.KeyAndValueMatch(resultDic, "message", "We have 1, \"two\", and False.");
         }
 
@@ -254,7 +254,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Assert.That(resultDic, Contains.Key("timestamp"));
             Assert.That(testOutputSink.InputsAndOutputs[0].LogEvent.Timestamp.ToUnixTimeMilliseconds(),
                 Is.EqualTo(resultDic["timestamp"].GetInt64()));
@@ -281,7 +281,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Assert.That(resultDic, Contains.Key("log.level"));
             Assert.That(testOutputSink.InputsAndOutputs[0].LogEvent.Level.ToString(),Is.EqualTo(resultDic["log.level"].GetString()));
         }
@@ -310,7 +310,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
             //additional 1 for threadid
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties + 1, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties + 1, resultDic);
             Assert.That(resultDic, Contains.Key("thread.id"));
             Assert.That(testOutputSink.InputsAndOutputs[0].LogEvent.Properties[ThreadIDKey].ToString(),Is.EqualTo(resultDic["thread.id"].GetString()));
         }
@@ -339,7 +339,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties + 3, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties + 3, resultDic);
             Asserts.KeyAndValueMatch(resultDic, "error.message", TestErrMsg);
             Asserts.KeyAndValueMatch(resultDic, "error.class", testException.GetType().FullName);
             Asserts.KeyAndValueMatch(resultDic, "error.stack", testException.StackTrace);
@@ -369,7 +369,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties + 2, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties + 2, resultDic);
             Assert.That(resultDic, Does.Not.ContainKey("error.message"));
             Asserts.KeyAndValueMatch(resultDic, "error.class", testException.GetType().FullName);
             Asserts.KeyAndValueMatch(resultDic, "error.stack", testException.StackTrace);
@@ -392,7 +392,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties + 2, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties + 2, resultDic);
             Assert.That(resultDic, Does.Not.ContainKey("error.stack"));
             Asserts.KeyAndValueMatch(resultDic, "error.message", TestErrMsg);
             Asserts.KeyAndValueMatch(resultDic, "error.class", testException.GetType().FullName);
@@ -422,7 +422,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
 
             var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
 
-            AssertThatPropertyCountsMatch(testEnricher, countIntrinsicProperties, resultDic);
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
             Asserts.KeyAndValueMatch(resultDic, UserPropertyKeyPrefix + IntegerTestKey, IntegerTestValue);
             Assert.That(resultDic, Does.Not.ContainKey(UserPropertyKeyPrefix + LinkingMetadataKey));
             Asserts.KeyAndValueMatch(resultDic, StringATestKey, "TestValue1");


### PR DESCRIPTION
This PR implements New Relic log4net appender which uses the New Relic agent api to capture transaction info to add to log events.