### PR TITLE
Invalid JSON Properties due to hard-coded prefix

### DIFF
--- a/src/shared/LoggingExtensions.cs
+++ b/src/shared/LoggingExtensions.cs
@@ -26,7 +26,7 @@ namespace NewRelic.LogEnrichers
 
     internal static class LoggingExtensions
     {
-        public const string UserPropertyPrefix = "Message Properties.";
+        public const string UserPropertyPrefix = "Message.Properties.";
 
         public static string GetOutputName(this NewRelicLoggingProperty property)
         {


### PR DESCRIPTION
There currently is a bug which means properties with spaces aren't query-able on the Log UI. Due to any additional fields being prefixed with "Message Properties." means properties like request path from ASP.Net aren't query-able. I have resolved this by making the hierarchy JSON compliant so that it is possible to query them. 

There is a discussion about this this in Support Ticket #387834