### PR TITLE
Remove space from user properties key

### DIFF
--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
@@ -15,7 +15,7 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
 {
     public class Log4NetLayoutTests
     {
-        private const string UserPropertyKeyPrefix = "Message Properties.";
+        private const string UserPropertyKeyPrefix = LoggingExtensions.UserPropertyPrefix;
 
         private IAgent _testAgent;
         private NewRelicAppender _testAppender;

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
@@ -15,7 +15,7 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
 {
     public class Log4NetLayoutTests
     {
-        private const string UserPropertyKeyPrefix = LoggingExtensions.UserPropertyPrefix;
+        private const string UserPropertyKeyPrefix = "Message.Properties.";
 
         private IAgent _testAgent;
         private NewRelicAppender _testAppender;

--- a/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -23,7 +23,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
 
         private const string TestErrMsg = "This is a test exception";
         private const string LogMessage = "This is a log message";
-        private readonly string UserPropertiesKey = NewRelicJsonLayout.UserPropertyKey;
+        private readonly string UserPropertiesKey = "Message.Properties";
 
         private static readonly Dictionary<string,string> linkingMetadataDict = new Dictionary<string, string>
             {

--- a/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -23,7 +23,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
 
         private const string TestErrMsg = "This is a test exception";
         private const string LogMessage = "This is a log message";
-        private const string UserPropertiesKey = "Message Properties";
+        private readonly string UserPropertiesKey = NewRelicJsonLayout.UserPropertyKey;
 
         private static readonly Dictionary<string,string> linkingMetadataDict = new Dictionary<string, string>
             {

--- a/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -23,7 +23,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
 
         private const string TestErrMsg = "This is a test exception";
         private const string LogMessage = "This is a log message";
-        private readonly string UserPropertiesKey = "Message.Properties";
+        private const string UserPropertiesKey = "Message.Properties";
 
         private static readonly Dictionary<string,string> linkingMetadataDict = new Dictionary<string, string>
             {

--- a/src/NLog/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
@@ -18,7 +18,7 @@ namespace NewRelic.LogEnrichers.NLog
         private IJsonConverter _jsonConverter;
         private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
 
-        internal readonly static string UserPropertyKey = LoggingExtensions.UserPropertyPrefix.Substring(0, LoggingExtensions.UserPropertyPrefix.Length - 1);
+        internal readonly static string UserPropertyKey = LoggingExtensions.UserPropertyPrefix.TrimEnd('.');
 
         private readonly JsonLayout _jsonLayoutForMessageProperties;
 

--- a/src/NLog/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
@@ -18,6 +18,8 @@ namespace NewRelic.LogEnrichers.NLog
         private IJsonConverter _jsonConverter;
         private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
 
+        internal readonly static string UserPropertyKey = LoggingExtensions.UserPropertyPrefix.Substring(0, LoggingExtensions.UserPropertyPrefix.Length - 1);
+
         private readonly JsonLayout _jsonLayoutForMessageProperties;
 
         internal NewRelicJsonLayout(Func<NewRelic.Api.Agent.IAgent> agentFactory) : base()
@@ -60,7 +62,7 @@ namespace NewRelic.LogEnrichers.NLog
                 ExcludeProperties = ExcludeProperties
             };
 
-            Attributes.Add(new JsonAttribute("Message Properties", _jsonLayoutForMessageProperties, false));
+            Attributes.Add(new JsonAttribute(UserPropertyKey, _jsonLayoutForMessageProperties, false));
         }
 
         public NewRelicJsonLayout() : this(NewRelic.Api.Agent.NewRelic.GetAgent)

--- a/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
+++ b/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
@@ -11,7 +11,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
     public class FormatterTests
     {
         private const string LinkingMetadataKey = "newrelic.linkingmetadata";
-        private const string UserPropertyKeyPrefix = "Message Properties.";
+        private const string UserPropertyKeyPrefix = LoggingExtensions.UserPropertyPrefix;
         private const string SingleAtSignTestKey = "@SingleAtSignTestKey";
         private const string DoubleAtSignTestKey = "@@DoubleAtSignTestKey";
         private const string IntegerTestKey = "IntegerTestKey";

--- a/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
+++ b/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
@@ -11,7 +11,7 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
     public class FormatterTests
     {
         private const string LinkingMetadataKey = "newrelic.linkingmetadata";
-        private const string UserPropertyKeyPrefix = LoggingExtensions.UserPropertyPrefix;
+        private const string UserPropertyKeyPrefix = "Message.Properties.";
         private const string SingleAtSignTestKey = "@SingleAtSignTestKey";
         private const string DoubleAtSignTestKey = "@@DoubleAtSignTestKey";
         private const string IntegerTestKey = "IntegerTestKey";

--- a/src/shared/LoggingExtensions.cs
+++ b/src/shared/LoggingExtensions.cs
@@ -26,7 +26,7 @@ namespace NewRelic.LogEnrichers
 
     internal static class LoggingExtensions
     {
-        public const string UserPropertyPrefix = "Message Properties.";
+        public const string UserPropertyPrefix = "Message.Properties.";
 
         public static string GetOutputName(this NewRelicLoggingProperty property)
         {


### PR DESCRIPTION
Spaces in attribute names break search functionality in the logs UI.  This issue was initially brought to our attention in this PR: https://github.com/newrelic/newrelic-logenricher-dotnet/pull/51 

I decided to do some additional refactoring to avoid having to update the user properties key in multiple locations in unit tests.