### PR TITLE
Update Readme.md with Log4Net link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For the latest information, please see the [New Relic docs](https://docs.newreli
 |-------------------------|-----------|
 | [Serilog](src/Serilog/README.md)             | 2.5+      |
 | [NLog](src/NLog/README.md)                   | 4.5+      |
+| [Log4Net](src/Log4Net/NewRelic.LogEnrichers.Log4Net/README.md) | 2.0.8+ |
 
 
 ## Minimum Requirements


### PR DESCRIPTION
**Update the readme.md with a link to the Log4Net extension.**
It seems that the two that are listed have very high adoption rates, and log4net is almost none.

[Here are some usage trends for NuGet](https://nugettrends.com/packages?months=6&ids=NewRelic.LogEnrichers.NLog&ids=NewRelic.LogEnrichers.Serilog&ids=NewRelic.Telemetry&ids=OpenTelemetry.Exporter.NewRelic&ids=NewRelic.LogEnrichers.Log4Net)