### PR TITLE
updates repolinter

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1
+        continue-on-error: true
         with:
-          config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-plus.json
+          config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-plus.yml
           output_type: issue


### PR DESCRIPTION
Since forks don't have access to Azure secrets required to run Sonar, creating this branch from this fork: https://github.com/prototypicalpro/newrelic-logenricher-dotnet