### PR TITLE
C# 8.0 + Nullable Reference Types + WarningsAsErrors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,2 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 </Project>

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/Program.cs
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/Program.cs
@@ -11,7 +11,7 @@ namespace NewRelic.LogEnrichers.Log4Net.Examples
 {
     static class Program
     {
-        private static ILog _logger;
+        private static ILog? _logger;
 
         static void Main(string[] args)
         {
@@ -38,8 +38,14 @@ namespace NewRelic.LogEnrichers.Log4Net.Examples
             GlobalContext.Properties["NewRelicLogFileName"] = @$"{folderPath_NewRelicLogs}\Log4NetExample.json";
 
             var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
-            XmlConfigurator.Configure(logRepository, new FileInfo("log4net.config"));
-            _logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+            if (logRepository != null)
+            {
+                XmlConfigurator.Configure(logRepository, new FileInfo("log4net.config"));
+            }
+
+
+            _logger = LogManager.GetLogger(MethodBase.GetCurrentMethod()?.DeclaringType);
 
             // This log information will be visible in New Relic Logging. Since 
             // a transaction has not been started, this log message will not be
@@ -67,9 +73,9 @@ namespace NewRelic.LogEnrichers.Log4Net.Examples
 
         [Transaction]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void TestMethod(object obj)
+        private static void TestMethod(object? obj)
         {
-            _logger.Info(@$"Starting TestMethod");
+            _logger?.Info(@$"Starting TestMethod");
 
             try
             {
@@ -81,17 +87,17 @@ namespace NewRelic.LogEnrichers.Log4Net.Examples
                     }
 
                     Console.WriteLine("writing message");
-                    _logger.Info(@$"This is log message {cnt}");
+                    _logger?.Info(@$"This is log message {cnt}");
                 }
             }
             catch (Exception ex)
             {
                 Console.WriteLine("Error has occurred in TestMethod");
                 Api.Agent.NewRelic.NoticeError(ex);
-                _logger.Error("Error has occurred in TestMethod", ex);
+                _logger?.Error("Error has occurred in TestMethod", ex);
             }
 
-            _logger.Info(@$"Ending TestMethod");
+            _logger?.Info(@$"Ending TestMethod");
         }
     }
 }

--- a/examples/NewRelic.LogEnrichers.NLog.Examples/Program.cs
+++ b/examples/NewRelic.LogEnrichers.NLog.Examples/Program.cs
@@ -11,7 +11,7 @@ namespace NewRelic.LogEnrichers.NLog.Examples
 {
     static class Program
     {
-        private static Logger _logger;
+        private static Logger? _logger;
 
         static void Main(string[] args)
         {
@@ -109,22 +109,22 @@ namespace NewRelic.LogEnrichers.NLog.Examples
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void TestMethod(string testVal)
         {
-            _logger.Info("Starting TestMethod - {testValue}", testVal);
+            _logger?.Info("Starting TestMethod - {testValue}", testVal);
 
             try
             {
                 for (var cnt = 0; cnt < 10; cnt++)
                 {
                     Console.WriteLine("writing message");
-                    _logger.Info("This is log message #{MessageID}", cnt);
+                    _logger?.Info("This is log message #{MessageID}", cnt);
                 }
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Error has occurred in TestMethod - {testValue}", testVal);
+                _logger?.Error(ex, "Error has occurred in TestMethod - {testValue}", testVal);
             }
 
-            _logger.Info("Ending TestMethod - {testValue}", testVal);
+            _logger?.Info("Ending TestMethod - {testValue}", testVal);
         }
     }
 }

--- a/examples/NewRelic.LogEnrichers.Serilog.Examples/Program.cs
+++ b/examples/NewRelic.LogEnrichers.Serilog.Examples/Program.cs
@@ -9,7 +9,7 @@ namespace NewRelic.LogEnrichers.Serilog.Examples
 {
     static class Program
     {
-        private static Logger _logger;
+        private static Logger? _logger;
 
         static void Main(string[] args)
         {
@@ -108,22 +108,22 @@ namespace NewRelic.LogEnrichers.Serilog.Examples
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void TestMethod(string testVal)
         {
-            _logger.Information("Starting TestMethod - {testValue}", testVal);
+            _logger?.Information("Starting TestMethod - {testValue}", testVal);
 
             try
             {
                 for(var cnt =0; cnt < 10; cnt++)
                 {
                     Console.WriteLine("writing message");
-                    _logger.Information("This is log message #{MessageID}", cnt);
+                    _logger?.Information("This is log message #{MessageID}", cnt);
                 }
             }
             catch(Exception ex)
             {
-                _logger.Error(ex, "Error has occurred in TestMethod - {testValue}", testVal);
+                _logger?.Error(ex, "Error has occurred in TestMethod - {testValue}", testVal);
             }
 
-            _logger.Information("Ending TestMethod - {testValue}", testVal);
+            _logger?.Information("Ending TestMethod - {testValue}", testVal);
         }
 
     }

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>NewRelic.LogEnrichers.Log4Net.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.Log4Net.Tests</RootNamespace>
+    <Nullable>disable</Nullable>
 
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <LangVersion>7.1</LangVersion>
     <RootNamespace>NewRelic.LogEnrichers.Log4Net</RootNamespace>
     <AssemblyName>NewRelic.LogEnrichers.Log4Net</AssemblyName>
-
     <Title>New Relic Logging Extension for Log4Net</Title>
     <Description>.NET library for sending logging context data to New Relic</Description>
     <Authors>newrelic</Authors>

--- a/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicLayout.cs
+++ b/src/Log4Net/NewRelic.LogEnrichers.Log4Net/NewRelicLayout.cs
@@ -32,11 +32,6 @@ namespace NewRelic.LogEnrichers.Log4Net
 
         private void SetInstrinsics(Dictionary<string, object> dictionary, LoggingEvent loggingEvent)
         {
-            if (dictionary == null)
-            {
-                return;
-            }
-
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.Timestamp), loggingEvent.TimeStamp.ToUnixTimeMilliseconds());
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.ThreadName), loggingEvent.ThreadName);
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.MessageText), loggingEvent.RenderedMessage);
@@ -45,11 +40,6 @@ namespace NewRelic.LogEnrichers.Log4Net
 
         private void SetExceptionData(Dictionary<string, object> dictionary, LoggingEvent loggingEvent) 
         {
-            if (dictionary == null)
-            {
-                return;
-            }
-
             if (loggingEvent.ExceptionObject != null)
             {
                 if (!string.IsNullOrEmpty(loggingEvent.ExceptionObject.Message))
@@ -69,11 +59,7 @@ namespace NewRelic.LogEnrichers.Log4Net
         private void SetUserProperties(Dictionary<string, object> dictionary, LoggingEvent e)
         {
             var properties = e.GetProperties();
-            if (dictionary == null)
-            {
-                return;
-            }
-
+            
             foreach (var key in properties.GetKeys())
             {
                 if (key != LinkingMetadataKey)
@@ -85,11 +71,6 @@ namespace NewRelic.LogEnrichers.Log4Net
 
         private void SetLinkMetaData(Dictionary<string, object> dictionary, LoggingEvent e)
         {
-            if (dictionary == null)
-            {
-                return;
-            }
-
             if (e.Properties[LinkingMetadataKey] is Dictionary<string, string> linkdata)
             {
                 foreach (var kv in linkdata)

--- a/src/NLog/NewRelic.LogEnrichers.NLog.Tests/NewRelic.LogEnrichers.NLog.Tests.csproj
+++ b/src/NLog/NewRelic.LogEnrichers.NLog.Tests/NewRelic.LogEnrichers.NLog.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>NewRelic.LogEnrichers.NLog.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.NLog.Tests</RootNamespace>
     <SignAssembly>true</SignAssembly>
+    <Nullable>disable</Nullable>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\..\NewRelic.LogEnrichers.StrongNameKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NLog/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
+++ b/src/NLog/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <LangVersion>7.1</LangVersion>
     <RootNamespace>NewRelic.LogEnrichers.NLog</RootNamespace>
     <AssemblyName>NewRelic.LogEnrichers.NLog</AssemblyName>
-
     <Title>New Relic Logging Extension for NLog</Title>
     <Description>.NET library for sending logging context data to New Relic</Description>
     <Authors>newrelic</Authors>

--- a/src/NLog/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
+++ b/src/NLog/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
@@ -15,7 +15,7 @@ namespace NewRelic.LogEnrichers.NLog
 
         private readonly Lazy<NewRelic.Api.Agent.IAgent> _nrAgent;
 
-        private IJsonConverter _jsonConverter;
+        private IJsonConverter? _jsonConverter;
         private IJsonConverter JsonConverter => _jsonConverter ?? (_jsonConverter = ConfigurationItemFactory.Default.JsonConverter);
 
         internal readonly static string UserPropertyKey = LoggingExtensions.UserPropertyPrefix.TrimEnd('.');

--- a/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/NewRelic.LogEnrichers.Serilog.Tests.csproj
+++ b/src/Serilog/NewRelic.LogEnrichers.Serilog.Tests/NewRelic.LogEnrichers.Serilog.Tests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>NewRelic.LogEnrichers.Serilog.Tests</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
+    <Nullable>disable</Nullable>
     <AssemblyOriginatorKeyFile>..\..\..\NewRelic.LogEnrichers.StrongNameKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/src/Serilog/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
+++ b/src/Serilog/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <LangVersion>7.1</LangVersion>
     <RootNamespace>NewRelic.LogEnrichers.Serilog</RootNamespace>
     <AssemblyName>NewRelic.LogEnrichers.Serilog</AssemblyName>
 

--- a/src/shared/LoggingExtensions.cs
+++ b/src/shared/LoggingExtensions.cs
@@ -70,7 +70,7 @@ namespace NewRelic.LogEnrichers
             }
         }
 
-        private static NewRelicLoggingProperty[] _allNewRelicLoggingProperties;
+        private static NewRelicLoggingProperty[]? _allNewRelicLoggingProperties;
         public static NewRelicLoggingProperty[] AllNewRelicLoggingProperties => 
             _allNewRelicLoggingProperties ?? (_allNewRelicLoggingProperties = Enum.GetValues(typeof(NewRelicLoggingProperty)).Cast<NewRelicLoggingProperty>().ToArray());
       


### PR DESCRIPTION
Fixes issue #66 

* Enables C# v8.0 Language Features in support of nullable reference types.
* annotates nullable types in parameters and results
* Makes C# 8.0, nullable enabled, and warnings as errors default for projects (excluding tests)
