### PR TITLE
Create assignproj.yml

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -1,0 +1,22 @@
+name: Auto Assign to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.DOTNET_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to Dotnet Engineering Board
+
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/newrelic/projects/20'
+        column_name: 'Triage'


### PR DESCRIPTION
Auto-assign new issues and pr on a "create event" to the Engineering Project board.

Test:
Test by creating an issue/pr in the log enricher repo and let the action autorun.  Once completed the Projects field will automatically assign to the Dotnet Engineering board.