### PR TITLE
Explicitly use UTF-8 encoding in examples

### DIFF
--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>Logging.Log4Net.Examples</AssemblyName>
   </PropertyGroup>
 

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/log4net.config
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/log4net.config
@@ -13,7 +13,7 @@
   <appender name="ToJsonFormatAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
     <param name="AppendToFile" value="true" />
-    <encoding type="System.Text.UTF8Encoding"/>
+    <encoding type="System.Text.UTF8Encoding, System.Text.Encoding.Extensions"/>
     <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
     </layout>
   </appender>
@@ -21,7 +21,7 @@
   <appender name="ToLogFormatAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{StandardLogFileName}" />
     <param name="AppendToFile" value="true" />
-    <encoding type="System.Text.UTF8Encoding"/>
+    <encoding type="System.Text.UTF8Encoding, System.Text.Encoding.Extensions"/>
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
     </layout>

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/log4net.config
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/log4net.config
@@ -13,7 +13,8 @@
   <appender name="ToJsonFormatAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
     <param name="AppendToFile" value="true" />
-    <encoding type="System.Text.UTF8Encoding, System.Text.Encoding.Extensions"/>
+    <!-- uncomment the next line to get UTF-8 logs if using .NET Framework -->
+    <!-- <encoding type="System.Text.UTF8Encoding"/> -->
     <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
     </layout>
   </appender>
@@ -21,7 +22,8 @@
   <appender name="ToLogFormatAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{StandardLogFileName}" />
     <param name="AppendToFile" value="true" />
-    <encoding type="System.Text.UTF8Encoding, System.Text.Encoding.Extensions"/>
+    <!-- uncomment the next line to get UTF-8 logs if using .NET Framework -->
+    <!-- <encoding type="System.Text.UTF8Encoding"/> -->
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
     </layout>

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/log4net.config
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/log4net.config
@@ -13,6 +13,7 @@
   <appender name="ToJsonFormatAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
     <param name="AppendToFile" value="true" />
+    <encoding type="System.Text.UTF8Encoding"/>
     <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
     </layout>
   </appender>
@@ -20,6 +21,7 @@
   <appender name="ToLogFormatAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{StandardLogFileName}" />
     <param name="AppendToFile" value="true" />
+    <encoding type="System.Text.UTF8Encoding"/>
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
     </layout>

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelicLayout.cs
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelicLayout.cs
@@ -39,7 +39,7 @@ namespace NewRelic.LogEnrichers.Log4Net
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.Timestamp), loggingEvent.TimeStamp.ToUnixTimeMilliseconds());
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.ThreadName), loggingEvent.ThreadName);
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.MessageText), loggingEvent.RenderedMessage);
-            dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.LogLevel), loggingEvent.Level);
+            dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.LogLevel), loggingEvent.Level.Name);
         }
 
         private void SetExceptionData(Dictionary<string, object> dictionary, LoggingEvent loggingEvent)

--- a/src/NewRelic.LogEnrichers.Log4Net/README.md
+++ b/src/NewRelic.LogEnrichers.Log4Net/README.md
@@ -50,6 +50,7 @@ Configuration of the New Relic extensions for ```log4net``` may be accomplished 
   <appender name="FileAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
     <param name="AppendToFile" value="true" />
+    <encoding type="System.Text.UTF8Encoding"/>
     <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
     </layout>
   </appender>
@@ -80,6 +81,7 @@ The example code below creates a logger based on settings contained in an `App.c
     <appender name="FileAppender" type="log4net.Appender.FileAppender">
       <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
       <param name="AppendToFile" value="true" />
+      <encoding type="System.Text.UTF8Encoding"/>
       <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
       </layout>
     </appender>

--- a/src/NewRelic.LogEnrichers.Log4Net/README.md
+++ b/src/NewRelic.LogEnrichers.Log4Net/README.md
@@ -50,7 +50,7 @@ Configuration of the New Relic extensions for ```log4net``` may be accomplished 
   <appender name="FileAppender" type="log4net.Appender.FileAppender">
     <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
     <param name="AppendToFile" value="true" />
-    <encoding type="System.Text.UTF8Encoding"/>
+    <encoding type="System.Text.UTF8Encoding, System.Text.Encoding.Extensions"/>
     <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
     </layout>
   </appender>
@@ -81,7 +81,7 @@ The example code below creates a logger based on settings contained in an `App.c
     <appender name="FileAppender" type="log4net.Appender.FileAppender">
       <file type="log4net.Util.PatternString" value="%property{NewRelicLogFileName}" />
       <param name="AppendToFile" value="true" />
-      <encoding type="System.Text.UTF8Encoding"/>
+      <encoding type="System.Text.UTF8Encoding, System.Text.Encoding.Extensions"/>
       <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
       </layout>
     </appender>

--- a/tests/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
+++ b/tests/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
@@ -73,8 +73,8 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
 
             // Assert
             Assert.That(deserializedMessage.ContainsKey("log.level"), "log.level not found.");
-            var resultLevel = TestHelpers.DeserializeOutputJSON(deserializedMessage["log.level"].ToString());
-            Assert.That(resultLevel["Name"].ToString() == level, "Incorrect logging level");
+            var logLevel = deserializedMessage["log.level"].ToString();
+            Assert.That(logLevel == level, "Incorrect logging level");
 
             Assert.That(deserializedMessage.ContainsKey("thread.name"), "thread.name not found.");
             var threadName = deserializedMessage["thread.name"].ToString();


### PR DESCRIPTION
The log4net `FileAppender` uses `Encoding.GetEncoding(0)` (https://git-wip-us.apache.org/repos/asf?p=logging-log4net.git;a=blob;f=src/log4net/Appender/FileAppender.cs;h=dbade37f7165e72eef22e5586b69b7c750c8e132;hb=HEAD#l1493) which will return UTF-8 on .NET Core 3.1, but Windows-1252 on .NET Framework 4.8.

This updates the configuration in the documentation to help people fall into the "pit of success" by setting it to use a UTF-8 encoding (without a BOM). Having no BOM is critical for logging to work if log files are rotated; see https://support.newrelic.com/tickets/433611/.