### PR TITLE
Upgrade agent API to 8.35.0

### DIFF
--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.21.34" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.21.34" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.21.34" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />

--- a/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.20.262" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/src/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
+++ b/src/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.21.34" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/src/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
+++ b/src/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/src/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
+++ b/src/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
+++ b/src/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.20.262" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
   </ItemGroup>

--- a/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="JustMock" Version="2019.3.910.4" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.20.262" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="JustMock" Version="2019.3.910.4" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.35.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />


### PR DESCRIPTION
Resolves #77 by upgrading the agent API version referenced by all projects to 8.35.0.

Testing: all unit tests pass.  I have not done any integration/smoke testing.

This change mainly enables better Intellisense and compiler warnings in these projects.  It should not have any impact on runtime behavior of the libraries.  Therefore I do not think a changelog entry or a release is necessary.