### PR TITLE
Add 'logger.name' property to NLog and Log4Net layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Add `logger.name` to NLog and Log4Net
+- A new property named `logger.name` is added to the New Relic layouts for NLog and Log4Net, with the value of the name of the logger that created the log event.
 
 ## [Log4Net_v1.0.2] - 2020-10-28
 ### Bugfix release

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelicLayout.cs
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelicLayout.cs
@@ -40,6 +40,7 @@ namespace NewRelic.LogEnrichers.Log4Net
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.ThreadName), loggingEvent.ThreadName);
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.MessageText), loggingEvent.RenderedMessage);
             dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.LogLevel), loggingEvent.Level.Name);
+            dictionary.Add(LoggingExtensions.GetOutputName(NewRelicLoggingProperty.LoggerName), loggingEvent.LoggerName);
         }
 
         private void SetExceptionData(Dictionary<string, object> dictionary, LoggingEvent loggingEvent)

--- a/src/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
+++ b/src/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
@@ -46,6 +46,7 @@ namespace NewRelic.LogEnrichers.NLog
             Attributes.Add(new JsonAttribute(NewRelicLoggingProperty.LogLevel.GetOutputName(), "${level:upperCase=true}", true));
             Attributes.Add(new JsonAttribute(NewRelicLoggingProperty.MessageText.GetOutputName(), "${message}", true));
             Attributes.Add(new JsonAttribute(NewRelicLoggingProperty.MessageTemplate.GetOutputName(), "${message:raw=true}"));
+            Attributes.Add(new JsonAttribute(NewRelicLoggingProperty.LoggerName.GetOutputName(), "${logger}", true));
 
             // correlation
             Attributes.Add(new JsonAttribute(NewRelicLoggingProperty.ThreadId.GetOutputName(), "${threadid}", true));

--- a/src/NewRelic.LogEnrichers.NLog/README.md
+++ b/src/NewRelic.LogEnrichers.NLog/README.md
@@ -101,6 +101,7 @@ In addition to the linking metadata obtained from the .NET Agent, the ```NewReli
 * Message Text
 * Message Template
 * Log Level
+* Logger Name
 * Thread Id
 * Activity Id
 * Process Id

--- a/src/shared/LoggingExtensions.cs
+++ b/src/shared/LoggingExtensions.cs
@@ -26,6 +26,7 @@ namespace NewRelic.LogEnrichers
         LineNumber,
         CorrelationId,
         ProcessId,
+        LoggerName,
     }
 
     internal static class LoggingExtensions
@@ -68,6 +69,8 @@ namespace NewRelic.LogEnrichers
                     return "correlation.id";
                 case NewRelicLoggingProperty.ProcessId:
                     return "process.id";
+                case NewRelicLoggingProperty.LoggerName:
+                    return "logger.name";
                 default:
                     throw new KeyNotFoundException($"New Relic Logging Field {property}");
             }

--- a/tests/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
+++ b/tests/NewRelic.LogEnrichers.Log4Net.Tests/Log4NetLayoutTests.cs
@@ -87,6 +87,10 @@ namespace NewRelic.LogEnrichers.Log4Net.Tests
             Assert.That(deserializedMessage.ContainsKey("timestamp"), "timestamp not found.");
             var timestamp = deserializedMessage["timestamp"].GetInt64();
             Assert.That(le.TimeStamp.ToUnixTimeMilliseconds(), Is.EqualTo(timestamp));
+
+            Assert.That(deserializedMessage.ContainsKey("logger.name"), "logger.name not found.");
+            var loggerName = deserializedMessage["logger.name"].ToString();
+            Assert.That(le.LoggerName, Is.EqualTo(loggerName));
         }
 
         [Test]

--- a/tests/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/tests/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -23,6 +23,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
         private const string TestErrMsg = "This is a test exception";
         private const string LogMessage = "This is a log message";
         private const string UserPropertiesKey = "Message.Properties";
+        private const string CustomLoggerName = "CustomLogger";
 
         private static readonly Dictionary<string, string> LinkingMetadataDict = new Dictionary<string, string>
         {
@@ -53,7 +54,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
 
             LogManager.Configuration = config;
 
-            _logger = LogManager.GetLogger("testLogger");
+            _logger = LogManager.GetCurrentClassLogger();
         }
 
         [TearDown]
@@ -192,6 +193,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.LogLevel.GetOutputName(), "INFO");
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.ThreadId.GetOutputName(), Thread.CurrentThread.ManagedThreadId.ToString());
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.ProcessId.GetOutputName(), Process.GetCurrentProcess().Id.ToString());
+            Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.LoggerName.GetOutputName(), _logger.Name);
             Assert.IsTrue(resultsDictionary.ContainsKey(NewRelicLoggingProperty.Timestamp.GetOutputName()));
             Assert.That(resultsDictionary, Does.Not.ContainKey(NewRelicLoggingProperty.LineNumber.GetOutputName()));
             foreach (var key in LinkingMetadataDict.Keys)
@@ -216,7 +218,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
 
             LogManager.Configuration = config;
 
-            var logger = LogManager.GetLogger("customAttributeLogger");
+            var logger = LogManager.GetLogger(CustomLoggerName);
 
             // Act
             logger.Info(LogMessage);
@@ -228,6 +230,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.LogLevel.GetOutputName(), "INFO");
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.ThreadId.GetOutputName(), Thread.CurrentThread.ManagedThreadId.ToString());
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.ProcessId.GetOutputName(), Process.GetCurrentProcess().Id.ToString());
+            Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.LoggerName.GetOutputName(), logger.Name);
             Assert.IsTrue(resultsDictionary.ContainsKey(NewRelicLoggingProperty.Timestamp.GetOutputName()));
             Assert.That(resultsDictionary, Does.ContainKey(NewRelicLoggingProperty.LineNumber.GetOutputName()));
             foreach (var key in LinkingMetadataDict.Keys)
@@ -255,6 +258,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.LogLevel.GetOutputName(), "INFO");
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.ThreadId.GetOutputName(), Thread.CurrentThread.ManagedThreadId.ToString());
             Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.ProcessId.GetOutputName(), Process.GetCurrentProcess().Id.ToString());
+            Asserts.KeyAndValueMatch(resultsDictionary, NewRelicLoggingProperty.LoggerName.GetOutputName(), _logger.Name);
             Assert.IsTrue(resultsDictionary.ContainsKey(NewRelicLoggingProperty.Timestamp.GetOutputName()));
             Assert.IsTrue(wasRun);
             foreach (var key in LinkingMetadataDict.Keys)
@@ -380,7 +384,7 @@ namespace NewRelic.LogEnrichers.NLog.Tests
 
             LogManager.Configuration = config;
 
-            var logger = LogManager.GetLogger("customAttributeLogger");
+            var logger = LogManager.GetLogger(CustomLoggerName);
 
             var alice = new Person { Name = "Alice", Manager = null };
             var bob = new Person { Name = "Bob", Manager = alice };


### PR DESCRIPTION
This PR resolves issue #96 by adding a 'logger.name' property to the layouts for NLog and Log4Net, which will contain the name of the logger which logged the log event.  When using a logger created by the `GetCurrentClassLogger()` method in either NLog or Log4Net, this value will be the name of the class from which the logger was created.

Note: Serilog does not appear to have a simple, always-present property or method on its log events for getting the name of the logger which logged the event, so I was unable to add this new property for Serilog.

Testing:
Added additional unit tests for NLog and Log4Net for the new property.
Manual testing with the NLog example application, verified that the new property is being sent to NR Logs and is displayed as expected.


