### PR TITLE
Markdown link check action

### DIFF
--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -1,0 +1,15 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        #use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        #config-file: 'mlc_config.json'
+        #max-depth: 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are always welcome. Before contributing please [search the issue tracker](https://github.com/newrelic/newrelic-logenricher-dotnet/issues); your issue may have already been discussed or fixed. To contribute,
+Contributions are always welcome. Before contributing please [read the code of conduct](https://opensource.newrelic.com/code-of-conduct/) and [search the issue tracker](https://github.com/newrelic/newrelic-logenricher-dotnet/issues); your issue may have already been discussed or fixed. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
 ## Feature Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,13 @@
 # Contributing
 
-Contributions are always welcome. Before contributing please read the
-[code of conduct](./CODE_OF_CONDUCT.md) and [search the issue tracker](issues); your issue may have already been discussed or fixed. To contribute,
+Contributions are always welcome. Before contributing please [search the issue tracker](https://github.com/newrelic/newrelic-logenricher-dotnet/issues); your issue may have already been discussed or fixed. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
-
-Note that our [code of conduct](./CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
 
 ## Feature Requests
 
-Feature requests should be submitted in the [Issue tracker](../../issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/), has been [shown by the community](../../issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
-Before submitting an Issue, please search for similar ones in the
-[closed issues](../../issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
+Feature requests should be submitted in the [Issue tracker](https://github.com/newrelic/newrelic-logenricher-dotnet/issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/), has been [shown by the community](https://github.com/newrelic/newrelic-logenricher-dotnet/issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
+Before submitting an issue, please search for similar ones in the
+[closed issues](https://github.com/newrelic/newrelic-logenricher-dotnet/issues?q=is%3Aissue+is%3Aclosed).
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ For the latest information, please see the [New Relic docs](https://docs.newreli
 
 | Framework               | Version   |
 |-------------------------|-----------|
-| [Serilog](src/Serilog/README.md)             | 2.5+      |
-| [NLog](src/NLog/README.md)                   | 4.5+      |
-| [Log4Net](src/Log4Net/NewRelic.LogEnrichers.Log4Net/README.md) | 2.0.8+ |
+| [Serilog](src/NewRelic.LogEnrichers.Serilog/README.md)             | 2.5+      |
+| [NLog](src/NewRelic.LogEnrichers.NLog/README.md)                   | 4.5+      |
+| [Log4Net](src/NewRelic.LogEnrichers.Log4Net/README.md) | 2.0.8+ |
 
 
 ## Minimum Requirements
@@ -32,7 +32,7 @@ If the issue has been confirmed as a bug or is a Feature request, please file a 
 **Support Channels**
 
 * [New Relic Documentation](https://docs.newrelic.com/docs/agents/net-agent): Comprehensive guidance for using our agent
-* [New Relic Community](https://discuss.newrelic.com/c/support-products-agents/net-agent): The best place to engage in troubleshooting questions
+* [New Relic Community](https://discuss.newrelic.com/tags/c/full-stack-observability/agents/.netagent): The best place to engage in troubleshooting questions
 * [New Relic Developer](https://developer.newrelic.com/): Resources for building a custom observability applications
 * [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
 * [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan). 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ As noted in our [security policy](https://github.com/newrelic/newrelic-logenrich
 
 If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
 
-If you would like to contribute to this project, please review [these guidelines](/CONTRIBUTING.md).
+If you would like to contribute to this project, please review [these guidelines](CONTRIBUTING.md).
 
 To [all contributors](https://github.com/newrelic/newrelic-logenricher-dotnet/graphs/contributors), we thank you!  Without your contribution, this project would not be what it is today.  We also host a community project page dedicated to
 the [New Relic .NET Logging Extensions](https://opensource.newrelic.com/projects/newrelic/newrelic-logenricher-dotnet).


### PR DESCRIPTION
This PR adds an action to check for broken links in all markdown files in this repo.  It also fixes some broken links which had crept in without our noticing them (which demonstrates the need for this check!).