### PR TITLE
Security update: reference log4net 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security fix: update log4net package reference to 2.0.10
+- To mitigate a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2018-1285) in log4net versions prior to 2.0.10, the minimum version of log4net required to use the enricher library for log4net has been updated to 2.0.10. 
 
 ## [Log4Net_v1.1.0, NLog_v1.1.0]
 ### Add `logger.name` to NLog and Log4Net

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For the latest information, please see the [New Relic docs](https://docs.newreli
 |-------------------------|-----------|
 | [Serilog](src/NewRelic.LogEnrichers.Serilog/README.md)             | 2.5+      |
 | [NLog](src/NewRelic.LogEnrichers.NLog/README.md)                   | 4.5+      |
-| [Log4Net](src/NewRelic.LogEnrichers.Log4Net/README.md) | 2.0.8+ |
+| [Log4Net](src/NewRelic.LogEnrichers.Log4Net/README.md) | 2.0.10+ |
 
 
 ## Minimum Requirements

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>


### PR DESCRIPTION
This PR fixes this [CVE](https://nvd.nist.gov/vuln/detail/CVE-2018-1285) identified in the 2.0.8 version of log4net that our enricher library for log4net current references, by updating the reference to 2.0.10.

This will require any applications that reference our log4net enricher library to use log4net version 2.0.10+.