### PR TITLE
Remove hardcoded limits on IncludeMdc, IncludeMdlc, and IncludeAllProperties in InitializeLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Features
+- Adds optional support for sending the MappedDiagnosticsContext and MappedDiagnosticsLogicalContext to New Relic One for NLog.
+
 
 ## [Log4Net_v1.1.1]
 ### Security fix: update log4net package reference to 2.0.10

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Logging.Log4Net.Examples</AssemblyName>
   </PropertyGroup>
 

--- a/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Logging.NLog.Examples</AssemblyName>
   </PropertyGroup>
 

--- a/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Logging.Serilog.Examples</AssemblyName>
   </PropertyGroup>
 

--- a/src/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
+++ b/src/NewRelic.LogEnrichers.NLog/NewRelicJsonLayout.cs
@@ -92,10 +92,7 @@ namespace NewRelic.LogEnrichers.NLog
             // to the data, in a similar manner to how they would have added data via custom layout strings.
             // By default we will only support the data directly related to structured logging.
             // Note that any message properties will also be present in the Gdc, Mdc, and Mdlc contexts.
-            // IncludeGdc = false; // GDC not supported in NLog 4.5
-            IncludeAllProperties = false;
-            IncludeMdc = false;
-            IncludeMdlc = false;
+            // IncludeGdc = false; // GDC not supported in NLog 4.5 - customers can enable it themselves in later versions however
             RenderEmptyObject = false;
             SuppressSpaces = true;
         }

--- a/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>NewRelic.LogEnrichers.Log4Net.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.Log4Net.Tests</RootNamespace>
 

--- a/tests/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/tests/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -64,8 +64,6 @@ namespace NewRelic.LogEnrichers.NLog.Tests
             _testAgent = null;
         }
 
-        #region GetLinkingMetadata Specific
-
         [Test]
         public void GetLinkingMetadata_CalledOncePerLogMessage()
         {
@@ -575,10 +573,6 @@ namespace NewRelic.LogEnrichers.NLog.Tests
             Assert.That(resultsDictionary, Does.Not.ContainKey(NewRelicLoggingProperty.ErrorStack.GetOutputName()));
         }
 
-        #endregion
-
-        #region With MDC and MDLC
-
         [TestCase(true, true, "name with space", "value with space", "name_with_underscore", "value_with_underscore")]
         [TestCase(true, true, "name-with-hyphen", "value-with-hyphen", "keyname", "valuename")]
         [TestCase(true, true, "testing integer mdc", 5, "testing integer mdlc", 10)]
@@ -700,7 +694,5 @@ namespace NewRelic.LogEnrichers.NLog.Tests
                 Asserts.KeyAndValueMatch(resultsDictionary, key, LinkingMetadataDict[key]);
             }
         }
-
-        #endregion
     }
 }

--- a/tests/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
+++ b/tests/NewRelic.LogEnrichers.NLog.Tests/LayoutTests.cs
@@ -177,10 +177,6 @@ namespace NewRelic.LogEnrichers.NLog.Tests
             }
         }
 
-        #endregion
-
-        #region No MDC or MDLC
-
         [Test]
         public void LogMessage_NoAgent_VerifyAttributes()
         {

--- a/tests/NewRelic.LogEnrichers.Serilog.Tests/NewRelic.LogEnrichers.Serilog.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.Serilog.Tests/NewRelic.LogEnrichers.Serilog.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>NewRelic.LogEnrichers.Serilog.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.Serilog.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/shared/Asserts.cs
+++ b/tests/shared/Asserts.cs
@@ -12,6 +12,13 @@ namespace NewRelic.LogEnrichers
         public static void KeyAndValueMatch(Dictionary<string, JsonElement> resultDic, string key, object value)
         {
             Assert.That(resultDic, Contains.Key(key));
+
+            if (value == null)
+            {
+                Assert.IsTrue(resultDic[key].ValueKind == JsonValueKind.Null);
+                return;
+            }
+
             var valueType = value.GetType();
             if (valueType == typeof(string))
             {
@@ -28,6 +35,10 @@ namespace NewRelic.LogEnrichers
             else if (valueType == typeof(long))
             {
                 Assert.That(resultDic[key].GetInt64(), Is.EqualTo(value));
+            }
+            else if (valueType == typeof(double))
+            {
+                Assert.That(resultDic[key].GetDouble(), Is.EqualTo(value));
             }
             else if (valueType == typeof(JsonValueKind))
             {


### PR DESCRIPTION
Resolves #104 
Resolves #99 

Adds support for MDC and MDLC data in NLog
Still defaults to false for both IncludeMdc and IncludeMdlc
Can be set to true when configuring the NewRelicJsonLayout
Will add those items as attributes alongside the ones from GetLinkingMetadata
Added Unit tests to check various types including null and empty strings
Note: With empty/null keys, not data shows up in the JSON as expected
Note: With empty/null values, the keys will still show up in JSON and NROne, which handles it just fine

Also updates the tests and examples from netcoreapp3.0 to netcoreapp3.1 since 3.0 is deprecated.


