### PR TITLE
Updates NLog example to show enabling MDC and MDLC for NLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If the issue has been confirmed as a bug or is a Feature request, please file a 
 **Support Channels**
 
 * [New Relic Documentation](https://docs.newrelic.com/docs/agents/net-agent): Comprehensive guidance for using our agent
-* [New Relic Community](https://discuss.newrelic.com/tags/c/full-stack-observability/agents/.netagent): The best place to engage in troubleshooting questions
+* [New Relic Community](https://discuss.newrelic.com/tags/c/full-stack-observability/agents/466/dotnetagent): The best place to engage in troubleshooting questions
 * [New Relic Developer](https://developer.newrelic.com/): Resources for building a custom observability applications
 * [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
 * [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan). 


### PR DESCRIPTION
Resolves #105 

Now enables MDC and MDLC
Makes a call to each to add key-value pairs