### PR TITLE
Add WithUserPropertyPrefix to enable custom user property prefix

### DIFF
--- a/src/NewRelic.LogEnrichers.Serilog/NewRelicFormatter.cs
+++ b/src/NewRelic.LogEnrichers.Serilog/NewRelicFormatter.cs
@@ -45,8 +45,11 @@ namespace NewRelic.LogEnrichers.Serilog
             NewRelicLoggingProperty.LogLevel,
         };
 
+        private string _userPropertyPrefix;
+
         public NewRelicFormatter()
         {
+            _userPropertyPrefix = LoggingExtensions.UserPropertyPrefix;
         }
 
         public NewRelicFormatter WithPropertyMapping(string propertyName, NewRelicLoggingProperty outputAsNewRelicProperty)
@@ -57,6 +60,12 @@ namespace NewRelic.LogEnrichers.Serilog
             }
 
             _propertyMappings[propertyName] = LoggingExtensions.GetOutputName(outputAsNewRelicProperty);
+            return this;
+        }
+
+        public NewRelicFormatter WithUserPropertyPrefix(string userPropertyPrefix)
+        {
+            _userPropertyPrefix = userPropertyPrefix;
             return this;
         }
 
@@ -155,7 +164,7 @@ namespace NewRelic.LogEnrichers.Serilog
                 }
                 else
                 {
-                    WriteFormattedJsonData(LoggingExtensions.UserPropertyPrefix + key, kvp.Value, output);
+                    WriteFormattedJsonData(_userPropertyPrefix + key, kvp.Value, output);
                 }
             }
         }

--- a/tests/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
+++ b/tests/NewRelic.LogEnrichers.Serilog.Tests/FormatterTests.cs
@@ -95,6 +95,33 @@ namespace NewRelic.LogEnrichers.Serilog.Tests
         }
 
         /// <summary>
+        /// LogEvent User Property has custom prefix.
+        /// </summary>
+        [Test]
+        public void Output_UserProperty_CustomPrefix()
+        {
+            // Arrange
+            const string customPrefix = "Custom.Prefix.";
+            var testEnricher = new TestEnricher()
+                .WithUserPropValue(IntegerTestKey, IntegerTestValue)
+                .WithNewRelicMetadataValue(new Dictionary<string, string>());
+            var testOutputSink = new TestSinkWithFormatter(new NewRelicFormatter().WithUserPropertyPrefix(customPrefix));
+            var testLogger = SerilogTestHelpers.GetLogger(testOutputSink, testEnricher);
+
+            // Act
+            testLogger.Warning(LogMessage);
+
+            // Assert
+            AssertNoSerilogErrorsAndCountOutputs(_testRunDebugLogs, testOutputSink.InputsAndOutputs, LogMessage);
+
+            var resultDic = SerilogTestHelpers.DeserializeOutputJSON(testOutputSink.InputsAndOutputs[0]);
+
+            AssertThatPropertyCountsMatch(testEnricher, CountIntrinsicProperties, resultDic);
+            Asserts.KeyAndValueMatch(resultDic, customPrefix + IntegerTestKey, IntegerTestValue);
+            Assert.That(resultDic, Does.Not.ContainKey(customPrefix + LinkingMetadataKey));
+        }
+
+        /// <summary>
         /// Entry in NR dictionary has null value.
         /// </summary>
         [Test]


### PR DESCRIPTION
PR to allow custom user prefix for the Serilog Formatter. #121 