### PR TITLE
chore: Update Nuget packages, update tfm to minimum currently supported, update Readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
   build-test:
     name: Build Test Deploy
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       artifact_staging_path: ${{ github.workspace }}\artifactstaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [Log4Net_vx.x.x]
+### Security fix: update Newtonsoft.Json package reference to 13.0.3
+- Mitigates a [security vulnerability](https://security.snyk.io/vuln/SNYK-DOTNET-NEWTONSOFTJSON-2774678) in Newtonsoft.Json versions prior to 13.0.1.
+### Features
 - Updates icon and project url for nuget packages [#135](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/135)
-- Updates Nuget package version references, including NewtonSoft.Json which resolves a [security vulnerability](https://security.snyk.io/vuln/SNYK-DOTNET-NEWTONSOFTJSON-2774678). Updates build targets to currently supported versions (`net462` and `net7.0`). [#142](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/142)
+- Updates Nuget package version references. Updates build targets to currently supported versions (`net462` and `net7.0`). [#142](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/142)
+## [NLog_vx.x.x, Serilog_vx.x.x]
+### Features
+- Updates icon and project url for nuget packages [#135](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/135)
+- Updates Nuget package version references. Updates build targets to currently supported versions (`net462` and `net7.0`). [#142](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/142)
 
 ## [Serilog_v1.1.0] - 2022-11-29
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Update icon and project url for nuget packages [#135](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/135)
+- Updates icon and project url for nuget packages [#135](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/135)
+- Updates Nuget package version references, including NewtonSoft.Json which resolves a [security vulnerability](https://security.snyk.io/vuln/SNYK-DOTNET-NEWTONSOFTJSON-2774678). Updates build targets to currently supported versions (`net462` and `net7.0`). [#142](https://github.com/newrelic/newrelic-logenricher-dotnet/pull/142)
 
 ## [Serilog_v1.1.0] - 2022-11-29
 ### Features

--- a/NewRelic.LogEnrichers.sln
+++ b/NewRelic.LogEnrichers.sln
@@ -1,12 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29411.108
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{39172BF2-C5E4-4985-BFAB-1B5EF63E8BD6}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		azure-pipelines.yml = azure-pipelines.yml
 		CHANGELOG.md = CHANGELOG.md
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CONTRIBUTING.md = CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For the latest information, please see the [New Relic docs](https://docs.newreli
 
 ## Minimum Requirements
 
-* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.5+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET Core 2.0+</a>
+* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.6.2+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET 6.0+</a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes">New Relic .NET Agent 8.21+<a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/agents/net-agent/net-agent-api" target="_blank">New Relic .NET Agent API 8.21+</a>
 

--- a/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Log4Net.Examples/NewRelic.LogEnrichers.Log4Net.Examples.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Logging.Log4Net.Examples</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.NLog.Examples/NewRelic.LogEnrichers.NLog.Examples.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Logging.NLog.Examples</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
-    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.11.0" />
+    <PackageReference Include="NLog" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
+++ b/examples/NewRelic.LogEnrichers.Serilog.Examples/NewRelic.LogEnrichers.Serilog.Examples.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Logging.Serilog.Examples</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.11.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.LogEnrichers.Serilog.Examples/Program.cs
+++ b/examples/NewRelic.LogEnrichers.Serilog.Examples/Program.cs
@@ -17,7 +17,7 @@ namespace NewRelic.LogEnrichers.Serilog.Examples
 
         private static void Main(string[] args)
         {
-            Console.WriteLine("Welcome to the New Relic Logging Extentions for Serilog");
+            Console.WriteLine("Welcome to the New Relic Logging Extensions for Serilog");
             Console.WriteLine();
 
             if (args.Length == 0)

--- a/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
+++ b/src/NewRelic.LogEnrichers.Log4Net/NewRelic.LogEnrichers.Log4Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <RootNamespace>NewRelic.LogEnrichers.Log4Net</RootNamespace>
     <AssemblyName>NewRelic.LogEnrichers.Log4Net</AssemblyName>
     <Title>New Relic Logging Extension for Log4Net</Title>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +28,13 @@
   <ItemGroup>
     <Compile Include="..\shared\DateTimeExtensions.cs" Link="DateTimeExtensions.cs" />
     <Compile Include="..\shared\LoggingExtensions.cs" Link="LoggingExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/NewRelic.LogEnrichers.Log4Net/README.md
+++ b/src/NewRelic.LogEnrichers.Log4Net/README.md
@@ -4,7 +4,7 @@ The .NET Extensions for log4net will add contextual information from the .NET Ag
 
 ## Minimum Requirements
 
-* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.5+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET Core 2.0+</a>
+* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.6.2+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET 6.0+</a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes">New Relic .NET Agent 8.21+<a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/agents/net-agent/net-agent-api" target="_blank">New Relic .NET Agent API 8.21+</a>
 * <a target="_blank" href="https://logging.apache.org/log4net/">log4net 2.0.8+</a>

--- a/src/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
+++ b/src/NewRelic.LogEnrichers.NLog/NewRelic.LogEnrichers.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <RootNamespace>NewRelic.LogEnrichers.NLog</RootNamespace>
     <AssemblyName>NewRelic.LogEnrichers.NLog</AssemblyName>
     <Title>New Relic Logging Extension for NLog</Title>
@@ -27,6 +27,13 @@
   <ItemGroup>
     <Compile Include="..\shared\DateTimeExtensions.cs" Link="DateTimeExtensions.cs" />
     <Compile Include="..\shared\LoggingExtensions.cs" Link="LoggingExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/NewRelic.LogEnrichers.NLog/README.md
+++ b/src/NewRelic.LogEnrichers.NLog/README.md
@@ -4,7 +4,7 @@ The .NET Extensions for NLog will add contextual information from the .NET Agent
 
 ## Minimum Requirements
 
-* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.5+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET Core 2.0+</a>
+* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.6.2+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET 6.0+</a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes">New Relic .NET Agent 8.21+<a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/agents/net-agent/net-agent-api" target="_blank">New Relic .NET Agent API 8.21+</a>
 * <a target="_blank" href="https://nlog-project.org/">NLog 4.5+</a>

--- a/src/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
+++ b/src/NewRelic.LogEnrichers.Serilog/NewRelic.LogEnrichers.Serilog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <RootNamespace>NewRelic.LogEnrichers.Serilog</RootNamespace>
     <AssemblyName>NewRelic.LogEnrichers.Serilog</AssemblyName>
 
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,6 +29,13 @@
   <ItemGroup>
     <Compile Include="..\shared\DateTimeExtensions.cs" Link="DateTimeExtensions.cs" />
     <Compile Include="..\shared\LoggingExtensions.cs" Link="LoggingExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/NewRelic.LogEnrichers.Serilog/README.md
+++ b/src/NewRelic.LogEnrichers.Serilog/README.md
@@ -4,7 +4,7 @@ The .NET Extensions for Serilog will add contextual information from the .NET Ag
 
 ## Minimum Requirements
 
-* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.5+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET Core 2.0+</a>
+* Microsoft <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-framework">.NET Framework 4.6.2+</a> or  <a target="_blank" href="https://dotnet.microsoft.com/download/dotnet-core">.NET 6.0+</a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes">New Relic .NET Agent 8.21+<a>
 * <a target="_blank" href="https://docs.newrelic.com/docs/agents/net-agent/net-agent-api" target="_blank">New Relic .NET Agent API 8.21+</a>
 * <a target="_blank" href="https://serilog.net/">Serilog 2.5+</a>

--- a/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.Log4Net.Tests/NewRelic.LogEnrichers.Log4Net.Tests.csproj
@@ -1,24 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>NewRelic.LogEnrichers.Log4Net.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.Log4Net.Tests</RootNamespace>
 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JustMock" Version="2019.3.910.4" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.32.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="JustMock" Version="2023.2.601.35" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.11.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\shared\TestHelpers.cs" Link="TestHelpers.cs" />
     <Compile Include="..\shared\Asserts.cs" Link="Asserts.cs" />
     <ProjectReference Include="..\..\src\NewRelic.LogEnrichers.Log4Net\NewRelic.LogEnrichers.Log4Net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/NewRelic.LogEnrichers.NLog.Tests/NewRelic.LogEnrichers.NLog.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.NLog.Tests/NewRelic.LogEnrichers.NLog.Tests.csproj
@@ -1,22 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>NewRelic.LogEnrichers.NLog.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.NLog.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JustMock" Version="2019.3.910.4" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="JustMock" Version="2023.2.601.35" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\shared\TestHelpers.cs" Link="TestHelpers.cs" />
     <Compile Include="..\shared\Asserts.cs" Link="Asserts.cs" />
     <ProjectReference Include="..\..\src\NewRelic.LogEnrichers.NLog\NewRelic.LogEnrichers.NLog.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/NewRelic.LogEnrichers.Serilog.Tests/NewRelic.LogEnrichers.Serilog.Tests.csproj
+++ b/tests/NewRelic.LogEnrichers.Serilog.Tests/NewRelic.LogEnrichers.Serilog.Tests.csproj
@@ -1,22 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>NewRelic.LogEnrichers.Serilog.Tests</AssemblyName>
     <RootNamespace>NewRelic.LogEnrichers.Serilog.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JustMock" Version="2019.3.910.4" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="JustMock" Version="2023.2.601.35" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\shared\TestHelpers.cs" Link="TestHelpers.cs" />
     <Compile Include="..\shared\Asserts.cs" Link="Asserts.cs" />
     <ProjectReference Include="..\..\src\NewRelic.LogEnrichers.Serilog\NewRelic.LogEnrichers.Serilog.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves #141.
* Updates most NuGet package references to the latest version
    * Includes an update to Newtonsoft.Json that resolves a security vulnerability
    * `log4net`, `NLog` and `Serilog` packages in the log enricher projects remain unchanged, but those packages when referenced by the examples and unit test projects are updated to the latest version.
* Updates the build targets for the log enricher projects to target .NET 4.6.2 instead of .NET 4.5 and updates the example and unit test projects build targets to .NET 7.0 instead of .NET Core 3.1. 
* Updates README.md 